### PR TITLE
External hpfeeds

### DIFF
--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -10,17 +10,37 @@ source {{ hpfeeds_logger_dir }}/hpfeeds-logger/hpfeeds-logger-env/bin/activate
 cd {{ hpfeeds_logger_dir }}
 if [[ ! -f ./hpfeeds-logger.cfg ]]
 then
-    IDENT='hpfeeds-logger'
-    SECRET=`python -c 'import uuid;print str(uuid.uuid4()).replace("-","")'`
-    CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.events,uhp.events'
+    # Check if we pulled in a value from the sysconfig file, and if not set a sane default
+    HPFEEDS_HOST=${HPFEEDS_HOST:-'hpfeeds'}
+    HPFEEDS_PORT=${HPFEEDS_PORT:-10000}
+    IDENT=${IDENT:-'hpfeeds-logger'}
+    SECRET=${SECRET:-`python -c 'import uuid;print str(uuid.uuid4()).replace("-","")'`
+    CHANNELS=${CHANNELS:-'amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions,uhp.events'}
+    FORMATTER_NAME=${FORMATTER_NAME:-'splunk'}
+    FILELOG_ENABLED=${FILELOG_ENABLED:-false}
+    LOG_FILE=${LOG_FILE:-'/var/log/hpfeeds-logger/chn-splunk.log'}
+    SYSLOG_ENABLED=${SYSLOG_ENABLED:-false}
+    SYSLOG_HOST=${SYSLOG_HOST:-'localhost'}
+    SYSLOG_PORT=${SYSLOG_PORT:-514}
+    SYSLOG_FACILITY=${SYSLOG_FACILITY:-"USER"}
+    MONGODB_HOST=${MONGODB_HOST:-'mongodb'}
+    MONGODB_PORT=${MONGODB_PORT:-27017}
 
+    # copy the example logger.json.example file and edit in our variables
     cp {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json.example {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"host\": \"localhost\"/\"host\": \"${HPFEEDS_HOST}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"port\": 10000/\"port\": ${HPFEEDS_PORT}/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"ident\": \"splunk-logger\"/\"ident\": \"${IDENT}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"secret\": \"\"/\"secret\": \"${SECRET}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"formatter_name\": \"splunk\"/\"formatter_name\": \"${FORMATTER_NAME}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+
+    sed -i "s|\"filelog_enabled\": true|\"filelog_enabled\": ${FILELOG_ENABLED}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"log_file\": \"mhn-splunk-log.out\"|\"log_file\": \"${LOG_FILE}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+
+    sed -i "s|\"syslog_enabled\": false|\"syslog_enabled\": ${SYSLOG_ENABLED}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"syslog_host\": \"localhost\"|\"syslog_host\": \"${SYSLOG_HOST}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"syslog_port\": 514|\"syslog_port\": ${SYSLOG_PORT}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"syslog_facility\": \"user\"|\"syslog_facility\": \"${SYSLOG_FACILITY}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 
     # Generate config file for hpfeeds broker and register
     cd {{ hpfeeds_dir }}/hpfeeds/broker/

--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -27,9 +27,6 @@ then
     MONGODB_HOST=${MONGODB_HOST:-'mongodb'}
     MONGODB_PORT=${MONGODB_PORT:-27017}
 
-    # Please forgive me for this code
-    OUR_TEXT=`echo ${CHANNELS} | sed -e 's/^/\\\"/' -e 's/$/\\\"/' -e 's/,/\\\",\\\"/g' | tr ',' '\n' | sed -e 's/$/,/' -e '$s/,$//' -e 's/^/\\t/'`
-
     # copy the example logger.json.example file and edit in our variables
     cp {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json.example {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"host\": \"localhost\"/\"host\": \"${HPFEEDS_HOST}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
@@ -46,8 +43,15 @@ then
     sed -i "s|\"syslog_port\": 514|\"syslog_port\": ${SYSLOG_PORT}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"syslog_facility\": \"user\"|\"syslog_facility\": \"${SYSLOG_FACILITY}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 
+    # Please forgive me for this code
+    OLD_IFS=${IFS}
+    IFS='|'
+    OUR_TEXT=`echo ${CHANNELS} | sed -e 's/^/\\\"/' -e 's/$/\\\"/' -e 's/,/\\\",\\\"/g' | tr ',' '\n' | sed -e 's/$/,/' -e '$s/,$//' -e 's/^/\\t/'`
+
     # Please also forgive me for using perl
     perl -p -000 -e "s/CHANNEL_VAR/${OUR_TEXT}/" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+
+    IFS=${OLD_IFS}
 
     # Generate config file for hpfeeds broker and register
     cd {{ hpfeeds_dir }}/hpfeeds/broker/

--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -49,7 +49,7 @@ then
     OUR_TEXT=`echo ${CHANNELS} | sed -e 's/^/\\\"/' -e 's/$/\\\"/' -e 's/,/\\\",\\\"/g' | tr ',' '\n' | sed -e 's/$/,/' -e '$s/,$//' -e 's/^/\\t/'`
 
     # Please also forgive me for using perl
-    perl -p -000 -e "s/CHANNEL_VAR/${OUR_TEXT}/" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    perl -i -p -000 -e "s/CHANNEL_VAR/${OUR_TEXT}/" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 
     IFS=${OLD_IFS}
 

--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -27,6 +27,9 @@ then
     MONGODB_HOST=${MONGODB_HOST:-'mongodb'}
     MONGODB_PORT=${MONGODB_PORT:-27017}
 
+    # Please forgive me for this code
+    OUR_TEXT=`echo ${CHANNELS} | sed -e 's/^/\\\"/' -e 's/$/\\\"/' -e 's/,/\\\",\\\"/g' | tr ',' '\n' | sed -e 's/$/,/' -e '$s/,$//' -e 's/^/\\t/'`
+
     # copy the example logger.json.example file and edit in our variables
     cp {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json.example {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"host\": \"localhost\"/\"host\": \"${HPFEEDS_HOST}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
@@ -42,6 +45,9 @@ then
     sed -i "s|\"syslog_host\": \"localhost\"|\"syslog_host\": \"${SYSLOG_HOST}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"syslog_port\": 514|\"syslog_port\": ${SYSLOG_PORT}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"syslog_facility\": \"user\"|\"syslog_facility\": \"${SYSLOG_FACILITY}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+
+    # Please also forgive me for using perl
+    perl -p -000 -e "s/CHANNEL_VAR/${OUR_TEXT}/" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 
     # Generate config file for hpfeeds broker and register
     cd {{ hpfeeds_dir }}/hpfeeds/broker/

--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -30,7 +30,7 @@ then
     cp {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json.example {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"host\": \"localhost\"/\"host\": \"${HPFEEDS_HOST}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"port\": 10000/\"port\": ${HPFEEDS_PORT}/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
-    sed -i "s/\"ident\": \"splunk-logger\"/\"ident\": \"${IDENT}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s/\"ident\": \"hpfeeds-logger\"/\"ident\": \"${IDENT}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"secret\": \"\"/\"secret\": \"${SECRET}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"formatter_name\": \"splunk\"/\"formatter_name\": \"${FORMATTER_NAME}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 

--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -10,17 +10,37 @@ source {{ hpfeeds_logger_dir }}/hpfeeds-logger/hpfeeds-logger-env/bin/activate
 cd {{ hpfeeds_logger_dir }}
 if [[ ! -f ./hpfeeds-logger.cfg ]]
 then
-    IDENT='hpfeeds-logger'
-    SECRET=`python -c 'import uuid;print str(uuid.uuid4()).replace("-","")'`
-    CHANNELS='amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.events,uhp.events'
+    # Check if we pulled in a value from the sysconfig file, and if not set a sane default
+    HPFEEDS_HOST=${HPFEEDS_HOST:-'hpfeeds'}
+    HPFEEDS_PORT=${HPFEEDS_PORT:-10000}
+    IDENT=${IDENT:-'hpfeeds-logger'}
+    SECRET=${SECRET:-`python -c 'import uuid;print str(uuid.uuid4()).replace("-","")'`}
+    CHANNELS=${CHANNELS:-'amun.events,conpot.events,thug.events,beeswarm.hive,dionaea.capture,dionaea.connections,thug.files,beeswarn.feeder,cuckoo.analysis,kippo.sessions,cowrie.sessions,glastopf.events,glastopf.files,mwbinary.dionaea.sensorunique,snort.alerts,wordpot.events,p0f.events,suricata.events,shockpot.events,elastichoney.events,rdphoney.sessions,uhp.events'}
+    FORMATTER_NAME=${FORMATTER_NAME:-'splunk'}
+    FILELOG_ENABLED=${FILELOG_ENABLED:-false}
+    LOG_FILE=${LOG_FILE:-'/var/log/hpfeeds-logger/chn-splunk.log'}
+    SYSLOG_ENABLED=${SYSLOG_ENABLED:-false}
+    SYSLOG_HOST=${SYSLOG_HOST:-'localhost'}
+    SYSLOG_PORT=${SYSLOG_PORT:-514}
+    SYSLOG_FACILITY=${SYSLOG_FACILITY:-"USER"}
+    MONGODB_HOST=${MONGODB_HOST:-'mongodb'}
+    MONGODB_PORT=${MONGODB_PORT:-27017}
 
+    # copy the example logger.json.example file and edit in our variables
     cp {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json.example {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"host\": \"localhost\"/\"host\": \"${HPFEEDS_HOST}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"port\": 10000/\"port\": ${HPFEEDS_PORT}/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"ident\": \"splunk-logger\"/\"ident\": \"${IDENT}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"secret\": \"\"/\"secret\": \"${SECRET}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"formatter_name\": \"splunk\"/\"formatter_name\": \"${FORMATTER_NAME}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+
+    sed -i "s|\"filelog_enabled\": true|\"filelog_enabled\": ${FILELOG_ENABLED}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"log_file\": \"mhn-splunk-log.out\"|\"log_file\": \"${LOG_FILE}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+
+    sed -i "s|\"syslog_enabled\": false|\"syslog_enabled\": ${SYSLOG_ENABLED}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"syslog_host\": \"localhost\"|\"syslog_host\": \"${SYSLOG_HOST}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"syslog_port\": 514|\"syslog_port\": ${SYSLOG_PORT}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"syslog_facility\": \"user\"|\"syslog_facility\": \"${SYSLOG_FACILITY}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 
     # Generate config file for hpfeeds broker and register
     cd {{ hpfeeds_dir }}/hpfeeds/broker/

--- a/hpfeeds-logger.sysconfig
+++ b/hpfeeds-logger.sysconfig
@@ -4,9 +4,6 @@
 # Defaults here are for containers, but can be adjusted
 # after install for a regular server or to customize the containers
 
-HPFEEDS_HOST='hpfeeds'
-HPFEEDS_PORT=10000
-
 MONGODB_HOST='mongodb'
 MONGODB_PORT=27017
 
@@ -14,3 +11,14 @@ LOG_FILE=/var/log/hpfeeds-logger/chn-splunk.log
 
 # Options are arcsight, json_formatter, raw_json, splunk
 FORMATTER_NAME=splunk
+
+# To log data from an external HPFeeds stream, uncomment and fill out these
+# variables. Additionally, change the HPFEEDS_* variables to point to the
+# remote service.
+
+# IDENT=
+# SECRET=
+# CHANNELS=
+
+HPFEEDS_HOST='hpfeeds'
+HPFEEDS_PORT=10000

--- a/hpfeeds-logger/logger.json.example
+++ b/hpfeeds-logger/logger.json.example
@@ -18,8 +18,18 @@
         "shockpot.events",
         "p0f.events",
         "elastichoney.events",
-        "rdphoney.events"
+        "rdphoney.sessions",
+        "uhp.events"
     ],
-    "log_file": "mhn-splunk-log.out",
+    "filelog": {
+        "filelog_enabled": true,
+        "log_file": "mhn-splunk-log.out"
+    },
+    "syslog": {
+        "syslog_enabled": false,
+        "syslog_host": "localhost",
+        "syslog_port": 514,
+        "syslog_facility": "user"
+    },
     "formatter_name": "splunk"
 }

--- a/hpfeeds-logger/logger.json.example
+++ b/hpfeeds-logger/logger.json.example
@@ -4,22 +4,7 @@
     "ident": "hpfeeds-logger",
     "secret": "",
     "channels": [
-        "amun.events",
-        "cowrie.sessions",
-        "dionaea.connections",
-        "dionaea.capture",
-        "glastopf.events",
-        "beeswarm.hive",
-        "kippo.sessions",
-        "conpot.events",
-        "snort.alerts",
-        "suricata.events",
-        "wordpot.events",
-        "shockpot.events",
-        "p0f.events",
-        "elastichoney.events",
-        "rdphoney.sessions",
-        "uhp.events"
+CHANNEL_VAR
     ],
     "filelog": {
         "filelog_enabled": true,


### PR DESCRIPTION
This PR includes a brief history of my terrible coding practices, as well as functionality that enables an hpfeeds-logger container to consume data from an external (non-local, non-CHN) hpfeeds source. 

The majority of the changes are to the sample json file and the run script which parses the sysconfig file.