### PR TITLE
In which our hero adds logging for hashes captured

### DIFF
--- a/hpfeeds-logger/hpfeedslogger/processors.py
+++ b/hpfeeds-logger/hpfeedslogger/processors.py
@@ -305,6 +305,13 @@ def kippo_cowrie_sessions(identifier, payload, name, channel):
             msg['command'] = command
             messages.append(msg)
 
+    if dec.hashes:
+        for fhash in dec.hashes:
+            msg = dict(base_message)
+            msg['signature'] = 'File downloaded on {} honeypot'.format(name_lower)
+            msg['hash'] = fhash
+            messages.append(msg)
+
     return messages
 
 


### PR DESCRIPTION
This request adds logging of any file hashes captured on the cowrie/kippo honeypots. Apparently that was missing.

Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>