### PR TITLE
More file rotation options

### DIFF
--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -45,7 +45,7 @@ then
     sed -i "s|\"rotation_size_max\": \"100\"|\"rotation_size_max\": \"${ROTATION_SIZE_MAX}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"rotation_time_max\": \"24\"|\"rotation_time_max\": \"${ROTATION_TIME_MAX}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"rotation_time_unit\": \"h\"|\"rotation_time_unit\": \"${ROTATION_TIME_UNIT}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
-    sed -i "s|\"rotation_backups\": \"h\"|\"rotation_backups\": \"${ROTATION_BACKUPS}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"rotation_backups\": \"3\"|\"rotation_backups\": \"${ROTATION_BACKUPS}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 
     sed -i "s|\"syslog_enabled\": false|\"syslog_enabled\": ${SYSLOG_ENABLED}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"syslog_host\": \"localhost\"|\"syslog_host\": \"${SYSLOG_HOST}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json

--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -29,6 +29,7 @@ then
     ROTATION_STRATEGY=${ROTATION_STRATEGY:-'size'}
     ROTATION_SIZE_MAX=${ROTATION_SIZE_MAX:-100}
     ROTATION_TIME_MAX=${ROTATION_TIME_MAX:-24}
+    ROTATION_TIME_UNIT=${ROTATION_TIME_UNIT:-'h'}
 
     # copy the example logger.json.example file and edit in our variables
     cp {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json.example {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
@@ -43,6 +44,8 @@ then
     sed -i "s|\"rotation_strategy\": \"size\"|\"rotation_strategy\": \"${ROTATION_STRATEGY}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"rotation_size_max\": \"100\"|\"rotation_size_max\": \"${ROTATION_SIZE_MAX}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"rotation_time_max\": \"24\"|\"rotation_time_max\": \"${ROTATION_TIME_MAX}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"rotation_time_unit\": \"h\"|\"rotation_time_unit\": \"${ROTATION_TIME_UNIT}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
+    sed -i "s|\"rotation_backups\": \"h\"|\"rotation_backups\": \"${ROTATION_BACKUPS}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
 
     sed -i "s|\"syslog_enabled\": false|\"syslog_enabled\": ${SYSLOG_ENABLED}|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s|\"syslog_host\": \"localhost\"|\"syslog_host\": \"${SYSLOG_HOST}\"|g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json

--- a/hpfeeds-logger.sysconfig
+++ b/hpfeeds-logger.sysconfig
@@ -12,14 +12,22 @@ MONGODB_PORT=27017
 FILELOG_ENABLED="true"
 LOG_FILE="/var/log/hpfeeds-logger/chn-splunk.log"
 
-# Choose to rotate the log file based on 'size'(default) or 'time'
+# Choose to rotate the log file based on 'size'(default), 'time', or 'none'
+# Choosing 'none' is ideal if you want to handle rotation outside of the
+# container
 ROTATION_STRATEGY="size"
 
 # If rotating by 'size', the number of MB to rotate at
 ROTATION_SIZE_MAX=100
 
-# If rotating by 'time', the number of hours to rotate at
+# If rotating by 'time', the unit to count in; valid values are "m","h", and "d"
+ROTATION_TIME_UNIT=h
+
+# If rotating by 'time', the number of rotation_time_unit to rotate at
 ROTATION_TIME_MAX=24
+
+# How many backup files to keep when rotating in the container
+ROTATION_BACKUPS=3
 
 # Log to syslog
 SYSLOG_ENABLED=false

--- a/hpfeeds-logger/bin/hpfeeds-logger
+++ b/hpfeeds-logger/bin/hpfeeds-logger
@@ -52,12 +52,17 @@ def main():
         if config['filelog'] and config['filelog']['filelog_enabled']:
             logfile = config['filelog']['log_file']
 
+            if config['filelog']['rotation_backups']:
+                backups = int(config['filelog']['rotation_backups'])
+            else:
+                backups = 3
+
             if config['filelog']['rotation_strategy'] == 'size':
 
                 maxByt = int(
                     config['filelog']['rotation_size_max']) * 1024 * 1024
                 file_handler = RotatingFileHandler(logfile, maxBytes=maxByt,
-                                                   backupCount=3)
+                                                   backupCount=backups)
 
             elif config['filelog']['rotation_strategy'] == 'time':
                 rotation_interval = int(config['filelog']['rotation_time_max'])
@@ -73,14 +78,14 @@ def main():
 
                 file_handler = TimedRotatingFileHandler(logfile, when=rotation_unit,
                                                         interval=rotation_interval,
-                                                        backupCount=3)
+                                                        backupCount=backups)
             elif config['filelog']['rotation_strategy'] == 'none':
                 file_handler = WatchedFileHandler(logfile, mode='a')
             else:
                 logger.warning(
                     'Invalid rotation_strategy! Defaulting to 100 MB size rotation!')
                 file_handler = RotatingFileHandler(logfile, maxBytes=104857600,
-                                                   backupCount=3)
+                                                   backupCount=backups)
 
             file_handler.setFormatter(logging.Formatter('%(message)s'))
             data_logger.addHandler(file_handler)

--- a/hpfeeds-logger/bin/hpfeeds-logger
+++ b/hpfeeds-logger/bin/hpfeeds-logger
@@ -4,7 +4,8 @@ import json
 import hpfeeds
 import sys
 import logging
-from logging.handlers import RotatingFileHandler, SysLogHandler, TimedRotatingFileHandler
+from logging.handlers import RotatingFileHandler, SysLogHandler, \
+    TimedRotatingFileHandler, WatchedFileHandler
 from hpfeedslogger.formatters import splunk, arcsight, json_formatter, raw_json
 from hpfeedslogger import processors
 
@@ -17,9 +18,10 @@ FORMATTERS = {
 LOG_FORMAT = '%(asctime)s - %(levelname)s - %(name)s[%(lineno)s][%(threadName)s] - %(message)s'
 handler = logging.StreamHandler()
 handler.setFormatter(logging.Formatter(LOG_FORMAT))
-logger = logging.getLogger('logger')
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logger.addHandler(handler)
+
 
 def main():
     if len(sys.argv) < 2:
@@ -39,7 +41,8 @@ def main():
     processor = processors.HpfeedsMessageProcessor()
     formatter = FORMATTERS.get(config['formatter_name'])
     if not formatter:
-        logger.error('Unsupported data log formatter encountered: %s. Exiting.', config['formatter_name'])
+        logger.error('Unsupported data log formatter encountered: %s. Exiting.',
+                     config['formatter_name'])
         return 1
 
     data_logger = logging.getLogger('data')
@@ -50,19 +53,41 @@ def main():
             logfile = config['filelog']['log_file']
 
             if config['filelog']['rotation_strategy'] == 'size':
-                maxByt = int(config['filelog']['rotation_size_max']) * 1024 * 1024
-                file_handler = RotatingFileHandler(logfile, maxBytes=maxByt, backupCount=3)
+
+                maxByt = int(
+                    config['filelog']['rotation_size_max']) * 1024 * 1024
+                file_handler = RotatingFileHandler(logfile, maxBytes=maxByt,
+                                                   backupCount=3)
+
             elif config['filelog']['rotation_strategy'] == 'time':
-                file_handler = TimedRotatingFileHandler(logfile, when='h', interval=int(config['filelog']['rotation_time_max']), backupCount=3)
+                rotation_interval = int(config['filelog']['rotation_time_max'])
+                if config['filelog']['rotation_time_unit']:
+                    if config['filelog']['rotation_time_unit'].lower() in [
+                        'd','h','m']:
+                        rotation_unit = config['filelog']['rotation_time_unit'].lower()
+                    else:
+                        rotation_unit = 'h'
+                        logger.warning('Could not interpret '
+                                       'rotation_time_unit; defaulting to '
+                                       'hour (h)')
+
+                file_handler = TimedRotatingFileHandler(logfile, when=rotation_unit,
+                                                        interval=rotation_interval,
+                                                        backupCount=3)
+            elif config['filelog']['rotation_strategy'] == 'none':
+                file_handler = WatchedFileHandler(logfile, mode='a')
             else:
-                logger.warning('Invalid rotation_strategy! Defaulting to 100 MB size rotation!')
-                file_handler = RotatingFileHandler(logfile, maxBytes=104857600,backupCount=3)
+                logger.warning(
+                    'Invalid rotation_strategy! Defaulting to 100 MB size rotation!')
+                file_handler = RotatingFileHandler(logfile, maxBytes=104857600,
+                                                   backupCount=3)
 
             file_handler.setFormatter(logging.Formatter('%(message)s'))
             data_logger.addHandler(file_handler)
-            logger.info('Writing events to %s', logfile)
+            logger.info('Writing events to {0} using strategy {1}'.format(
+                logfile, config['filelog']['rotation_strategy']))
     except Exception as e:
-        logger.error("Invalid file handler arguments")
+        logger.error("Invalid file handler arguments: {0}".format(repr(e)))
         return 1
 
     try:
@@ -70,7 +95,8 @@ def main():
             syslog_host = config['syslog']['syslog_host'] or "localhost"
             syslog_port = config['syslog']['syslog_port'] or 514
             syslog_facility = config['syslog']['syslog_facility'] or "user"
-            file_handler = SysLogHandler(address=(syslog_host, syslog_port), facility=syslog_facility)
+            file_handler = SysLogHandler(address=(syslog_host, syslog_port),
+                                         facility=syslog_facility)
             file_handler.setFormatter(logging.Formatter('%(message)s'))
             data_logger.addHandler(file_handler)
             logger.info('Writing syslog events to %s', syslog_host)
@@ -90,7 +116,8 @@ def main():
         if config['formatter_name'] == "raw_json":
             data_logger.info(formatter(payload))
         else:
-            for msg in processor.process(identifier, channel, payload, ignore_errors=True):
+            for msg in processor.process(identifier, channel, payload,
+                                         ignore_errors=True):
                 data_logger.info(formatter(msg))
 
     def on_error(payload):
@@ -111,6 +138,7 @@ def main():
     finally:
         hpc.close()
     return 0
+
 
 if __name__ == '__main__':
     try:

--- a/hpfeeds-logger/logger.json.example
+++ b/hpfeeds-logger/logger.json.example
@@ -11,7 +11,9 @@ CHANNEL_VAR
         "log_file": "mhn-splunk-log.out",
         "rotation_strategy": "size",
         "rotation_size_max": "100",
-        "rotation_time_max": "24"
+        "rotation_time_max": "24",
+        "rotation_time_unit": "h",
+        "rotation_backups": "3"
     },
     "syslog": {
         "syslog_enabled": false,


### PR DESCRIPTION
Add option for not rotating the log files inside the honeypot, which would allow the user to rotate the file externally. 

Also fixes the rotation_backup option, as the previous sed would not change the value.