### PR TITLE
Adjust logic of hpfeeds registration to fail early in configuration process. Heroic.

### DIFF
--- a/hpfeeds-logger.run.j2
+++ b/hpfeeds-logger.run.j2
@@ -31,6 +31,17 @@ then
     ROTATION_TIME_MAX=${ROTATION_TIME_MAX:-24}
     ROTATION_TIME_UNIT=${ROTATION_TIME_UNIT:-'h'}
 
+    # Change into the HPFeeds dir, it's needed for hpfeeds scripts
+    pushd {{ hpfeeds_dir }}/hpfeeds/broker/
+
+    # Generate config file for hpfeeds broker and try to register
+    # Exit if failed
+    python {{ hpfeeds_dir }}/hpfeeds/broker/generateconfig.py unattended --mongo_host ${MONGODB_HOST} --mongo_port ${MONGODB_PORT} || exit 1
+    python {{ hpfeeds_dir }}/hpfeeds/broker/add_user.py "$IDENT" "$SECRET" "" "$CHANNELS" || exit 1
+
+    # Change back to {{ hpfeeds_logger_dir }} directory
+    popd
+
     # copy the example logger.json.example file and edit in our variables
     cp {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json.example {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
     sed -i "s/\"host\": \"localhost\"/\"host\": \"${HPFEEDS_HOST}\"/g" {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json
@@ -62,14 +73,9 @@ then
 
     IFS=${OLD_IFS}
 
-    # Generate config file for hpfeeds broker and register
-    cd {{ hpfeeds_dir }}/hpfeeds/broker/
-    python {{ hpfeeds_dir }}/hpfeeds/broker/generateconfig.py unattended --mongo_host ${MONGODB_HOST} --mongo_port ${MONGODB_PORT}
-    python {{ hpfeeds_dir }}/hpfeeds/broker/add_user.py "$IDENT" "$SECRET" "" "$CHANNELS"
 fi
 
 cd {{ hpfeeds_logger_dir}}/hpfeeds-logger/
 echo "Starting hpfeeds-logger..."
-
 export PYTHONPATH={{ hpfeeds_logger_dir }}/hpfeeds-logger
 exec python {{ hpfeeds_logger_dir }}/hpfeeds-logger/bin/hpfeeds-logger {{ hpfeeds_logger_dir }}/hpfeeds-logger/logger.json


### PR DESCRIPTION
with previous logic, timing issues in container start could cause container to write out a config that was not successfully registered, and thus always fail when connecting to hpfeeds (which would then cause errors on the hpfeeds side)

Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>