### PR TITLE
Syslog timestamp fixes

### DIFF
--- a/hpfeeds-logger/bin/hpfeeds-logger
+++ b/hpfeeds-logger/bin/hpfeeds-logger
@@ -15,7 +15,7 @@ FORMATTERS = {
     'json': json_formatter.format,
     'raw_json': raw_json.format
 }
-LOG_FORMAT = '%(asctime)s - %(levelname)s - %(name)s[%(lineno)s][%(threadName)s] - %(message)s'
+LOG_FORMAT = '%(asctime)s - %(levelname)s - %(name)s[%(lineno)s][%(filename)s] - %(message)s'
 handler = logging.StreamHandler()
 handler.setFormatter(logging.Formatter(LOG_FORMAT))
 logger = logging.getLogger(__name__)

--- a/hpfeeds-logger/bin/hpfeeds-logger
+++ b/hpfeeds-logger/bin/hpfeeds-logger
@@ -99,10 +99,10 @@ def main():
             syslog_host = config['syslog']['syslog_host'] or "localhost"
             syslog_port = config['syslog']['syslog_port'] or 514
             syslog_facility = config['syslog']['syslog_facility'] or "user"
-            file_handler = SysLogHandler(address=(syslog_host, syslog_port),
-                                         facility=syslog_facility)
-            file_handler.setFormatter(logging.Formatter('%(message)s'))
-            data_logger.addHandler(file_handler)
+            syslog_handler = SysLogHandler(address=(syslog_host, syslog_port),
+                                           facility=syslog_facility)
+            syslog_handler.setFormatter(logging.Formatter('%(message)s'))
+            data_logger.addHandler(syslog_handler)
             logger.info('Writing syslog events to %s', syslog_host)
     except Exception as e:
         logger.error('Invalid sysconfig arguments')

--- a/hpfeeds-logger/hpfeedslogger/formatters/arcsight.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/arcsight.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import datetime
+import time
 
 def format(message):
     tmpmsg = dict(message)
@@ -25,9 +26,12 @@ def format(message):
     }
     severity = severity_map.get(tmpmsg.get('severity'), "1")
     timestamp = datetime.datetime.isoformat(datetime.datetime.utcnow())
+    if time.tzname[0] == 'UTC':
+        timestamp += 'Z'
 
     # Set dynamic variables
-    outmsg = u"{} CEF:0|ThreatStream|MHN|1.0|{}|{}|{}|".format(timestamp, message['type'], message['signature'], severity)
+    outmsg = u"{} CEF:0|ThreatStream|MHN|1.0|{}|{}|{}|".format(timestamp, message['type'], message['signature'],
+                                                               severity)
 
     # Replace transport field with protocol value if blank
     tmpmsg['transport'] = tmpmsg.get('transport', tmpmsg['protocol'])

--- a/hpfeeds-logger/hpfeedslogger/formatters/arcsight.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/arcsight.py
@@ -30,8 +30,8 @@ def format(message):
         timestamp += 'Z'
 
     # Set dynamic variables
-    outmsg = u"{} CEF:0|ThreatStream|MHN|1.0|{}|{}|{}|".format(timestamp, message['type'], message['signature'],
-                                                               severity)
+    outmsg = u"{} CEF:0|STINGAR|CHN|1.0|{}|{}|{}|".format(timestamp, message['type'], message['signature'],
+                                                          severity)
 
     # Replace transport field with protocol value if blank
     tmpmsg['transport'] = tmpmsg.get('transport', tmpmsg['protocol'])

--- a/hpfeeds-logger/hpfeedslogger/formatters/json_formatter.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/json_formatter.py
@@ -1,8 +1,11 @@
 import json
 import datetime
-
+import time
 
 def format(message):
     msg = dict(message)
-    msg['timestamp'] = datetime.datetime.isoformat(datetime.datetime.utcnow())
+    t = datetime.datetime.isoformat(datetime.datetime.utcnow())
+    if time.tzname[0] == 'UTC':
+        t += 'Z'
+    msg['timestamp'] = t
     return json.dumps(msg)

--- a/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
@@ -21,4 +21,4 @@ def format(message):
 
     msg = u', '.join(
         [u'{}="{}"'.format(name, str(value).replace('"', '\\"')) for name, value in outmsg.items() if value])
-    return timestamp + u' ' + msg
+    return 'timestamp={}'.format(timestamp) + u' ' + msg

--- a/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 import datetime
+import time
 
 def format(message):
 
@@ -15,5 +16,9 @@ def format(message):
         del outmsg['dest_ip']
 
     timestamp = datetime.datetime.isoformat(datetime.datetime.utcnow())
-    msg = u', '.join([u'{}="{}"'.format(name, str(value).replace('"', '\\"')) for name, value in outmsg.items() if value])
+    if time.tzname[0] == 'UTC':
+        timestamp += 'Z'
+
+    msg = u', '.join(
+        [u'{}="{}"'.format(name, str(value).replace('"', '\\"')) for name, value in outmsg.items() if value])
     return timestamp + u' ' + msg

--- a/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
@@ -18,7 +18,9 @@ def format(message):
     timestamp = datetime.datetime.isoformat(datetime.datetime.utcnow())
     if time.tzname[0] == 'UTC':
         timestamp += 'Z'
+    outmsg['timestamp'] = timestamp
 
-    msg = u', '.join(
-        [u'{}="{}"'.format(name, str(value).replace('"', '\\"')) for name, value in outmsg.items() if value])
-    return 'timestamp={}'.format(timestamp) + ', ' + msg
+    d = [u'{}="{}"'.format(name, str(value).replace('"', '\\"')) for name, value in outmsg.items() if value]
+    msg = ', '.join(d)
+
+    return msg

--- a/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
@@ -21,4 +21,4 @@ def format(message):
 
     msg = u', '.join(
         [u'{}="{}"'.format(name, str(value).replace('"', '\\"')) for name, value in outmsg.items() if value])
-    return 'timestamp={}'.format(timestamp) + u' ' + msg
+    return 'timestamp={}'.format(timestamp) + ', ' + msg


### PR DESCRIPTION
This PR will adjust the way timestamps are injected with hpfeeds-logger to more cleanly include them. In the case the timezone is UTC (which is default) a `Z` will be appended to indicate the timezone is UTC. 

This also adjust the module so that file and syslog outputs are simultaneously supported in a single container. 

Remove some vestigial MHN references.