### PR TITLE
Create a new dictionary to ensure timestamp is the first key

### DIFF
--- a/hpfeeds-logger/hpfeedslogger/formatters/json_formatter.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/json_formatter.py
@@ -4,8 +4,14 @@ import time
 
 def format(message):
     msg = dict(message)
+    log = dict()
     t = datetime.datetime.isoformat(datetime.datetime.utcnow())
     if time.tzname[0] == 'UTC':
         t += 'Z'
     msg['timestamp'] = t
-    return json.dumps(msg)
+    # create a new object with timestamp first so it's output first
+    # This works on Python 3.6 and later as dictionaries keys are ordered by creation
+    log['timestamp'] = msg.pop('timestamp')
+    for item in msg:
+        log[item]=msg[item]
+    return json.dumps(log)


### PR DESCRIPTION
As of Python 3.6 dictionaries are ordered internally by creation time. So in current code, because the timestamp is formatted and added to the dictionary just before emitting the JSON string, the timestamp field is the last key in the message. This fact plays havoc with Splunk trying to read JSON because ¯\_(ツ)_/¯ .

This PR will ensure that timestamp is always the first field when emitted by the json formatter plugin.
Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>