### PR TITLE
Remove bytestring output from json and splunk formatters

### DIFF
--- a/hpfeeds-logger/hpfeedslogger/formatters/json_formatter.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/json_formatter.py
@@ -13,5 +13,9 @@ def format(message):
     # This works on Python 3.6 and later as dictionaries keys are ordered by creation
     log['timestamp'] = msg.pop('timestamp')
     for item in msg:
-        log[item]=msg[item]
+        if isinstance(msg[item], bytes):
+            log[item] = msg[item].decode('utf8')
+        else:
+            log[item] = msg[item]
+
     return json.dumps(log)

--- a/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
+++ b/hpfeeds-logger/hpfeedslogger/formatters/splunk.py
@@ -13,7 +13,10 @@ def format(message):
     outmsg['timestamp'] = timestamp
 
     for k, v in dict(message).items():
-        outmsg[k] = v
+        if isinstance(v, bytes):
+            outmsg[k] = v.decode('utf8')
+        else:
+            outmsg[k] = v
 
     if 'src_ip' in outmsg:
         outmsg['src'] = outmsg['src_ip']


### PR DESCRIPTION
Some honeypots, for some fields, are using bytestrings. This PR will ensure that any bytestrings are converted to UTF8 decoded strings before outputting to the Splunk or JSON formats.
Signed-off-by: Jesse Bowling <jesse.bowling@duke.edu>